### PR TITLE
Performance Work Finished

### DIFF
--- a/test/bench/exponential-backoff/description.txt
+++ b/test/bench/exponential-backoff/description.txt
@@ -1,0 +1,2 @@
+retrieveFromShard(shard *Shard[T, P]) got worse in comparison to the previous run. (pointer approach)
+ 

--- a/test/bench/exponential-backoff/text/BenchmarkGenPool/BenchmarkGenPool.txt
+++ b/test/bench/exponential-backoff/text/BenchmarkGenPool/BenchmarkGenPool.txt
@@ -1,0 +1,26 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/AlexsanderHamir/GenPool/test
+cpu: Apple M1
+BenchmarkGenPool-8   	 8316332	       172.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 6601576	       182.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 6649460	       182.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 7660075	       182.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 9306372	       182.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 6597361	       155.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 7735364	       182.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 6655003	       181.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 8324275	       177.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 9422479	       181.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 7799791	       130.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 9196920	       182.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 8150863	       183.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 9285895	       128.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 6615620	       182.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 7710411	       181.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 9332971	       182.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 9579162	       181.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 9192199	       182.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGenPool-8   	 7248211	       182.2 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/AlexsanderHamir/GenPool/test	37.491s

--- a/test/bench/exponential-backoff/text/BenchmarkGenPool/BenchmarkGenPool_cpu.txt
+++ b/test/bench/exponential-backoff/text/BenchmarkGenPool/BenchmarkGenPool_cpu.txt
@@ -1,0 +1,218 @@
+File: test.test
+Type: cpu
+Time: 2025-08-05 06:35:59 PDT
+Duration: 37.27s, Total samples = 219.28s (588.39%)
+Showing nodes accounting for 219.28s, 100% of 219.28s total
+      flat  flat%   sum%        cum   cum%
+     0.09s 0.041% 0.041%    212.35s 96.84%  testing.(*B).RunParallel.func1
+     0.26s  0.12%  0.16%    211.50s 96.45%  github.com/AlexsanderHamir/GenPool/test.BenchmarkGenPool.func1
+     4.88s  2.23%  2.39%    156.90s 71.55%  github.com/AlexsanderHamir/GenPool/pool.(*ShardedPool[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] },go.shape.*github.com/AlexsanderHamir/GenPool/test.BenchmarkObject]).Get
+    53.29s 24.30% 26.69%    104.68s 47.74%  github.com/AlexsanderHamir/GenPool/pool.(*ShardedPool[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] },go.shape.*github.com/AlexsanderHamir/GenPool/test.BenchmarkObject]).retrieveFromShard
+     0.04s 0.018% 26.71%     93.97s 42.85%  sync/atomic.(*Pointer[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] }]).CompareAndSwap (inline)
+    93.90s 42.82% 69.53%     93.93s 42.84%  sync/atomic.CompareAndSwapPointer
+    10.31s  4.70% 74.23%     54.06s 24.65%  github.com/AlexsanderHamir/GenPool/pool.(*ShardedPool[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] },go.shape.*github.com/AlexsanderHamir/GenPool/test.BenchmarkObject]).Put
+         0     0% 74.23%     46.97s 21.42%  github.com/AlexsanderHamir/GenPool/pool.(*Fields[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] }]).IncrementUsage
+    46.70s 21.30% 95.53%     46.97s 21.42%  sync/atomic.(*Int64).Add (inline)
+         0     0% 95.53%      4.95s  2.26%  runtime.goschedImpl
+         0     0% 95.53%      3.90s  1.78%  runtime.mcall
+         0     0% 95.53%      3.21s  1.46%  runtime.lock (partial-inline)
+     0.15s 0.068% 95.59%      3.21s  1.46%  runtime.lock2
+         0     0% 95.59%      3.21s  1.46%  runtime.lockWithRank (inline)
+     2.89s  1.32% 96.91%      2.89s  1.32%  runtime.usleep
+         0     0% 96.91%      2.84s  1.30%  runtime.osyield (inline)
+         0     0% 96.91%      2.80s  1.28%  runtime.gosched_m
+     0.44s   0.2% 97.11%      2.67s  1.22%  runtime.schedule
+         0     0% 97.11%      2.16s  0.99%  runtime.newstack
+         0     0% 97.11%      2.15s  0.98%  runtime.gopreempt_m (inline)
+         0     0% 97.11%      1.92s  0.88%  runtime.morestack
+     0.07s 0.032% 97.15%      1.84s  0.84%  runtime.findRunnable
+         0     0% 97.15%      0.94s  0.43%  runtime.goexit0
+         0     0% 97.15%      0.67s  0.31%  runtime.systemstack
+         0     0% 97.15%      0.66s   0.3%  runtime.semasleep
+     0.65s   0.3% 97.44%      0.65s   0.3%  runtime.pthread_cond_wait
+     0.01s 0.0046% 97.45%      0.63s  0.29%  runtime.newobject
+     0.07s 0.032% 97.48%      0.62s  0.28%  runtime.mallocgc
+     0.07s 0.032% 97.51%      0.61s  0.28%  runtime.wakep
+         0     0% 97.51%      0.57s  0.26%  runtime.unlock (inline)
+     0.13s 0.059% 97.57%      0.57s  0.26%  runtime.unlock2
+         0     0% 97.57%      0.57s  0.26%  runtime.unlockWithRank (inline)
+     0.56s  0.26% 97.82%      0.56s  0.26%  runtime.asyncPreempt
+     0.23s   0.1% 97.93%      0.55s  0.25%  runtime.mallocgcSmallScanNoHeader
+     0.51s  0.23% 98.16%      0.51s  0.23%  github.com/AlexsanderHamir/GenPool/pool.(*ShardedPool[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] },go.shape.*github.com/AlexsanderHamir/GenPool/test.BenchmarkObject]).getShard (inline)
+         0     0% 98.16%      0.46s  0.21%  runtime.stopm
+         0     0% 98.16%      0.44s   0.2%  runtime.mPark (inline)
+         0     0% 98.16%      0.44s   0.2%  runtime.notesleep
+         0     0% 98.16%      0.44s   0.2%  runtime.semawakeup
+     0.42s  0.19% 98.35%      0.42s  0.19%  runtime.pthread_cond_signal
+     0.01s 0.0046% 98.36%      0.41s  0.19%  runtime.unlock2Wake
+         0     0% 98.36%      0.38s  0.17%  runtime/pprof.profileWriter
+         0     0% 98.36%      0.36s  0.16%  runtime.execute
+     0.17s 0.078% 98.44%      0.34s  0.16%  runtime.casgstatus
+         0     0% 98.44%      0.32s  0.15%  runtime.gcBgMarkWorker.func2
+     0.02s 0.0091% 98.44%      0.32s  0.15%  runtime.gcDrain
+         0     0% 98.44%      0.31s  0.14%  github.com/AlexsanderHamir/GenPool/pool.(*Fields[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] }]).SetNext
+         0     0% 98.44%      0.31s  0.14%  sync/atomic.(*Pointer[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] }]).Store (inline)
+     0.31s  0.14% 98.59%      0.31s  0.14%  sync/atomic.StorePointer
+     0.28s  0.13% 98.71%      0.28s  0.13%  github.com/AlexsanderHamir/GenPool/test.cleaner
+         0     0% 98.71%      0.28s  0.13%  runtime.(*mheap).allocSpan
+     0.28s  0.13% 98.84%      0.28s  0.13%  runtime.madvise
+     0.28s  0.13% 98.97%      0.28s  0.13%  testing.(*PB).Next (inline)
+     0.06s 0.027% 99.00%      0.27s  0.12%  runtime.(*timers).check
+         0     0% 99.00%      0.25s  0.11%  runtime.sysUsed (inline)
+         0     0% 99.00%      0.25s  0.11%  runtime.sysUsedOS (inline)
+         0     0% 99.00%      0.23s   0.1%  runtime.gcDrainMarkWorkerIdle (inline)
+     0.01s 0.0046% 99.00%      0.23s   0.1%  runtime/pprof.readProfile
+     0.21s 0.096% 99.10%      0.21s 0.096%  runtime.(*profBuf).read
+     0.13s 0.059% 99.16%      0.20s 0.091%  runtime.globrunqget
+         0     0% 99.16%      0.18s 0.082%  runtime.(*gcWork).balance
+         0     0% 99.16%      0.18s 0.082%  runtime.nanotime (inline)
+     0.15s 0.068% 99.22%      0.18s 0.082%  runtime.nanotime1
+     0.18s 0.082% 99.31%      0.18s 0.082%  runtime.nextFreeFast (inline)
+     0.16s 0.073% 99.38%      0.18s 0.082%  runtime.runqget (inline)
+         0     0% 99.38%      0.16s 0.073%  runtime.(*mheap).allocManual
+         0     0% 99.38%      0.16s 0.073%  runtime.park_m
+         0     0% 99.38%      0.15s 0.068%  runtime.newproc.func1
+     0.05s 0.023% 99.40%      0.15s 0.068%  runtime/pprof.(*profileBuilder).addCPUData
+     0.01s 0.0046% 99.41%      0.14s 0.064%  runtime.(*timers).run
+         0     0% 99.41%      0.14s 0.064%  runtime.gcBgMarkWorker
+     0.01s 0.0046% 99.41%      0.14s 0.064%  runtime.newproc1
+     0.02s 0.0091% 99.42%      0.13s 0.059%  runtime.gfget
+         0     0% 99.42%      0.12s 0.055%  runtime.(*mheap).alloc.func1
+         0     0% 99.42%      0.12s 0.055%  runtime.preemptM
+     0.12s 0.055% 99.48%      0.12s 0.055%  runtime.pthread_kill
+         0     0% 99.48%      0.12s 0.055%  runtime.signalM (inline)
+         0     0% 99.48%      0.11s  0.05%  runtime.(*gcControllerState).enlistWorker
+         0     0% 99.48%      0.11s  0.05%  runtime.preemptone
+         0     0% 99.48%      0.10s 0.046%  runtime.stackalloc
+         0     0% 99.48%      0.10s 0.046%  runtime.stackcacherefill
+         0     0% 99.48%      0.10s 0.046%  runtime.stackpoolalloc
+     0.04s 0.018% 99.49%      0.10s 0.046%  runtime/pprof.(*profMap).lookup
+     0.02s 0.0091% 99.50%      0.09s 0.041%  runtime.(*timer).unlockAndRun
+         0     0% 99.50%      0.09s 0.041%  runtime.gcDrainMarkWorkerDedicated (inline)
+         0     0% 99.50%      0.09s 0.041%  runtime.getempty
+         0     0% 99.50%      0.09s 0.041%  runtime.gfget.func2
+         0     0% 99.50%      0.08s 0.036%  runtime.handoff
+     0.03s 0.014% 99.52%      0.08s 0.036%  runtime.scanobject
+     0.07s 0.032% 99.55%      0.07s 0.032%  runtime.(*gQueue).pop (inline)
+     0.04s 0.018% 99.57%      0.07s 0.032%  runtime.heapSetTypeNoHeader (inline)
+     0.01s 0.0046% 99.57%      0.06s 0.027%  runtime.(*gQueue).pushBack (inline)
+     0.02s 0.0091% 99.58%      0.06s 0.027%  runtime.Gosched
+         0     0% 99.58%      0.06s 0.027%  runtime.getempty.func1
+         0     0% 99.58%      0.06s 0.027%  runtime.globrunqput (inline)
+     0.04s 0.018% 99.60%      0.06s 0.027%  runtime.mapaccess1_fast64
+     0.01s 0.0046% 99.60%      0.06s 0.027%  runtime.stealWork
+         0     0% 99.60%      0.05s 0.023%  github.com/AlexsanderHamir/GenPool/pool.(*Fields[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] }]).GetNext
+         0     0% 99.60%      0.05s 0.023%  github.com/AlexsanderHamir/GenPool/test.BenchmarkGenPool
+     0.05s 0.023% 99.63%      0.05s 0.023%  gogo
+     0.05s 0.023% 99.65%      0.05s 0.023%  runtime.(*guintptr).set (inline)
+         0     0% 99.65%      0.05s 0.023%  runtime.goready (inline)
+         0     0% 99.65%      0.05s 0.023%  runtime.goroutineReady
+         0     0% 99.65%      0.05s 0.023%  runtime.goroutineReady.goready.func1
+     0.03s 0.014% 99.66%      0.05s 0.023%  runtime.ready
+         0     0% 99.66%      0.05s 0.023%  runtime.runqgrab
+         0     0% 99.66%      0.05s 0.023%  runtime.runqsteal
+     0.05s 0.023% 99.69%      0.05s 0.023%  sync/atomic.(*Pointer[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] }]).Load (inline)
+         0     0% 99.69%      0.05s 0.023%  testing.(*B).RunParallel
+         0     0% 99.69%      0.05s 0.023%  testing.(*B).runN
+     0.04s 0.018% 99.70%      0.04s 0.018%  internal/runtime/atomic.(*Uint32).CompareAndSwap (inline)
+         0     0% 99.70%      0.04s 0.018%  runtime.gdestroy
+         0     0% 99.70%      0.04s 0.018%  runtime.notewakeup
+         0     0% 99.70%      0.04s 0.018%  runtime.startm
+         0     0% 99.70%      0.03s 0.014%  github.com/AlexsanderHamir/GenPool/test.allocator
+     0.03s 0.014% 99.72%      0.03s 0.014%  internal/runtime/atomic.(*Uint8).Load (inline)
+     0.03s 0.014% 99.73%      0.03s 0.014%  runtime.(*mLockProfile).recordUnlock
+     0.02s 0.0091% 99.74%      0.03s 0.014%  runtime.(*mspan).writeHeapBitsSmall
+         0     0% 99.74%      0.03s 0.014%  runtime.(*pageAlloc).scavenge.func1
+         0     0% 99.74%      0.03s 0.014%  runtime.(*pageAlloc).scavengeOne
+     0.02s 0.0091% 99.75%      0.03s 0.014%  runtime.atomicwb
+     0.03s 0.014% 99.76%      0.03s 0.014%  runtime.divRoundUp (inline)
+         0     0% 99.76%      0.03s 0.014%  runtime.findObject
+         0     0% 99.76%      0.03s 0.014%  runtime.gcstopm
+     0.03s 0.014% 99.78%      0.03s 0.014%  runtime.libcCall
+         0     0% 99.78%      0.03s 0.014%  runtime.newproc
+         0     0% 99.78%      0.03s 0.014%  runtime.resetspinning
+         0     0% 99.78%      0.03s 0.014%  runtime.sysUnused (inline)
+         0     0% 99.78%      0.03s 0.014%  runtime.sysUnusedOS (inline)
+     0.01s 0.0046% 99.78%      0.03s 0.014%  runtime.traceAcquire (inline)
+     0.03s 0.014% 99.79%      0.03s 0.014%  runtime.traceEnabled (inline)
+         0     0% 99.79%      0.03s 0.014%  testing.(*B).launch
+     0.02s 0.0091% 99.80%      0.02s 0.0091%  internal/runtime/atomic.(*Uint32).Load (inline)
+         0     0% 99.80%      0.02s 0.0091%  runtime.(*gcWork).init
+         0     0% 99.80%      0.02s 0.0091%  runtime.(*gcWork).tryGet
+     0.02s 0.0091% 99.81%      0.02s 0.0091%  runtime.(*guintptr).cas (inline)
+     0.02s 0.0091% 99.82%      0.02s 0.0091%  runtime.(*lfstack).pop (inline)
+     0.02s 0.0091% 99.83%      0.02s 0.0091%  runtime.(*lfstack).push
+     0.01s 0.0046% 99.84%      0.02s 0.0091%  runtime.(*mcache).nextFree
+     0.01s 0.0046% 99.84%      0.02s 0.0091%  runtime.(*timer).updateHeap
+         0     0% 99.84%      0.02s 0.0091%  runtime.isSystemGoroutine
+     0.02s 0.0091% 99.85%      0.02s 0.0091%  runtime.kevent
+         0     0% 99.85%      0.02s 0.0091%  runtime.netpoll
+     0.02s 0.0091% 99.86%      0.02s 0.0091%  runtime.spanOf (inline)
+     0.02s 0.0091% 99.87%      0.02s 0.0091%  runtime.traceShuttingDown (inline)
+     0.01s 0.0046% 99.87%      0.02s 0.0091%  runtime.typePointers.next
+         0     0% 99.87%      0.02s 0.0091%  testing.(*B).run1.func1
+     0.01s 0.0046% 99.88%      0.01s 0.0046%  indexbytebody
+     0.01s 0.0046% 99.88%      0.01s 0.0046%  internal/runtime/atomic.(*Int32).CompareAndSwap (inline)
+     0.01s 0.0046% 99.89%      0.01s 0.0046%  internal/runtime/atomic.(*Int32).Load (inline)
+     0.01s 0.0046% 99.89%      0.01s 0.0046%  internal/runtime/atomic.(*Int64).Load (inline)
+     0.01s 0.0046% 99.90%      0.01s 0.0046%  internal/runtime/atomic.(*Uint64).Add (inline)
+     0.01s 0.0046% 99.90%      0.01s 0.0046%  internal/runtime/maps.(*Map).Used (inline)
+     0.01s 0.0046% 99.90%      0.01s 0.0046%  internal/runtime/maps.(*groupsReference).group (inline)
+     0.01s 0.0046% 99.91%      0.01s 0.0046%  runtime.(*gcControllerState).addScannableStack (inline)
+         0     0% 99.91%      0.01s 0.0046%  runtime.(*gcWork).put
+     0.01s 0.0046% 99.91%      0.01s 0.0046%  runtime.(*gcWork).tryGetFast (inline)
+         0     0% 99.91%      0.01s 0.0046%  runtime.(*mcache).refill
+         0     0% 99.91%      0.01s 0.0046%  runtime.(*mcentral).cacheSpan
+         0     0% 99.91%      0.01s 0.0046%  runtime.(*moduledata).funcName
+     0.01s 0.0046% 99.92%      0.01s 0.0046%  runtime.(*mspan).base (inline)
+         0     0% 99.92%      0.01s 0.0046%  runtime.(*pageAlloc).alloc
+     0.01s 0.0046% 99.92%      0.01s 0.0046%  runtime.(*pageAlloc).find
+         0     0% 99.92%      0.01s 0.0046%  runtime.(*sweepLocked).sweep.(*mheap).freeSpan.func2
+         0     0% 99.92%      0.01s 0.0046%  runtime.(*timeHistogram).record
+     0.01s 0.0046% 99.93%      0.01s 0.0046%  runtime.(*timer).unlock (inline)
+         0     0% 99.93%      0.01s 0.0046%  runtime.(*timers).adjust
+     0.01s 0.0046% 99.93%      0.01s 0.0046%  runtime.(*timers).deleteMin
+     0.01s 0.0046% 99.94%      0.01s 0.0046%  runtime.(*timers).wakeTime (inline)
+         0     0% 99.94%      0.01s 0.0046%  runtime.(*wbBuf).get2 (inline)
+         0     0% 99.94%      0.01s 0.0046%  runtime.acquireSudog
+     0.01s 0.0046% 99.94%      0.01s 0.0046%  runtime.acquirem (inline)
+         0     0% 99.94%      0.01s 0.0046%  runtime.copystack
+         0     0% 99.94%      0.01s 0.0046%  runtime.deductAssistCredit
+         0     0% 99.94%      0.01s 0.0046%  runtime.findfunc
+     0.01s 0.0046% 99.95%      0.01s 0.0046%  runtime.findmoduledatap (inline)
+         0     0% 99.95%      0.01s 0.0046%  runtime.findnull
+         0     0% 99.95%      0.01s 0.0046%  runtime.forEachPInternal
+         0     0% 99.95%      0.01s 0.0046%  runtime.funcname (inline)
+         0     0% 99.95%      0.01s 0.0046%  runtime.gcAssistAlloc
+         0     0% 99.95%      0.01s 0.0046%  runtime.gcAssistAlloc.func2
+         0     0% 99.95%      0.01s 0.0046%  runtime.gcAssistAlloc1
+         0     0% 99.95%      0.01s 0.0046%  runtime.gcMarkDone
+         0     0% 99.95%      0.01s 0.0046%  runtime.gcMarkTermination.forEachP.func6
+     0.01s 0.0046% 99.95%      0.01s 0.0046%  runtime.getGCMask (inline)
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.getMCache (inline)
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.gfput
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.gogo
+         0     0%   100%      0.01s 0.0046%  runtime.gostringnocopy (inline)
+         0     0%   100%      0.01s 0.0046%  runtime.greyobject
+         0     0%   100%      0.01s 0.0046%  runtime.markroot
+         0     0%   100%      0.01s 0.0046%  runtime.markroot.func1
+         0     0%   100%      0.01s 0.0046%  runtime.notetsleep
+         0     0%   100%      0.01s 0.0046%  runtime.notetsleep_internal
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.pidlegetSpinning
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.procyield
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.pthread_cond_timedwait_relative_np
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.pthread_mutex_lock
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.pthread_mutex_unlock
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.puintptr.ptr (inline)
+         0     0%   100%      0.01s 0.0046%  runtime.putempty
+         0     0%   100%      0.01s 0.0046%  runtime.putfull
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.releasem (inline)
+         0     0%   100%      0.01s 0.0046%  runtime.semacquire (inline)
+         0     0%   100%      0.01s 0.0046%  runtime.semacquire1
+         0     0%   100%      0.01s 0.0046%  runtime.startTheWorld.func1
+         0     0%   100%      0.01s 0.0046%  runtime.startTheWorldWithSema
+         0     0%   100%      0.01s 0.0046%  runtime.suspendG
+     0.01s 0.0046%   100%      0.01s 0.0046%  runtime.typePointers.nextFast (inline)
+         0     0%   100%      0.01s 0.0046%  runtime.wbBufFlush
+         0     0%   100%      0.01s 0.0046%  runtime.wbBufFlush.func1
+         0     0%   100%      0.01s 0.0046%  runtime.wbBufFlush1

--- a/test/bench/exponential-backoff/text/BenchmarkGenPool/BenchmarkGenPool_memory.txt
+++ b/test/bench/exponential-backoff/text/BenchmarkGenPool/BenchmarkGenPool_memory.txt
@@ -1,0 +1,39 @@
+File: test.test
+Type: alloc_space
+Time: 2025-08-05 06:36:36 PDT
+Showing nodes accounting for 94.11MB, 100% of 94.11MB total
+      flat  flat%   sum%        cum   cum%
+      31MB 32.94% 32.94%    44.50MB 47.29%  testing.(*B).RunParallel.func1
+         0     0% 32.94%       42MB 44.63%  github.com/AlexsanderHamir/GenPool/test.BenchmarkGenPool
+      42MB 44.63% 77.57%       42MB 44.63%  testing.(*B).RunParallel
+         0     0% 77.57%       42MB 44.63%  testing.(*B).runN
+         0     0% 77.57%    29.50MB 31.35%  testing.(*B).launch
+         0     0% 77.57%    13.50MB 14.35%  github.com/AlexsanderHamir/GenPool/pool.(*ShardedPool[go.shape.struct { Name string; Data []uint8; Result int64; github.com/AlexsanderHamir/GenPool/test._ [16]uint8; Fields = github.com/AlexsanderHamir/GenPool/pool.Fields[github.com/AlexsanderHamir/GenPool/test.BenchmarkObject] },go.shape.*github.com/AlexsanderHamir/GenPool/test.BenchmarkObject]).Get
+         0     0% 77.57%    13.50MB 14.35%  github.com/AlexsanderHamir/GenPool/test.BenchmarkGenPool.func1
+   13.50MB 14.35% 91.92%    13.50MB 14.35%  github.com/AlexsanderHamir/GenPool/test.allocator
+         0     0% 91.92%    12.50MB 13.28%  testing.(*B).run1.func1
+       4MB  4.25% 96.17%        4MB  4.25%  runtime.malg
+         0     0% 96.17%        4MB  4.25%  runtime.newproc.func1
+         0     0% 96.17%        4MB  4.25%  runtime.newproc1
+         0     0% 96.17%        4MB  4.25%  runtime.systemstack
+         0     0% 96.17%     2.10MB  2.23%  runtime/pprof.(*profileBuilder).appendLocsForStack
+         0     0% 96.17%     2.10MB  2.23%  runtime/pprof.(*profileBuilder).build
+         0     0% 96.17%     2.10MB  2.23%  runtime/pprof.profileWriter
+    0.53MB  0.57% 96.74%     1.10MB  1.17%  compress/flate.(*compressor).init
+         0     0% 96.74%     1.10MB  1.17%  compress/flate.NewWriter (inline)
+         0     0% 96.74%     1.10MB  1.17%  compress/gzip.(*Writer).Write
+         0     0% 96.74%     1.10MB  1.17%  runtime/pprof.(*profileBuilder).emitLocation
+         0     0% 96.74%     1.10MB  1.17%  runtime/pprof.(*profileBuilder).flush
+       1MB  1.06% 97.80%        1MB  1.06%  runtime.allocm
+         0     0% 97.80%        1MB  1.06%  runtime.mstart
+         0     0% 97.80%        1MB  1.06%  runtime.mstart0
+         0     0% 97.80%        1MB  1.06%  runtime.mstart1
+         0     0% 97.80%        1MB  1.06%  runtime.newm
+         0     0% 97.80%        1MB  1.06%  runtime.resetspinning
+         0     0% 97.80%        1MB  1.06%  runtime.schedule
+         0     0% 97.80%        1MB  1.06%  runtime.startm
+         0     0% 97.80%        1MB  1.06%  runtime.wakep
+       1MB  1.06% 98.86%        1MB  1.06%  runtime/pprof.allFrames
+    0.57MB   0.6% 99.47%     0.57MB   0.6%  compress/flate.newDeflateFast (inline)
+    0.50MB  0.53%   100%     0.50MB  0.53%  runtime.(*scavengerState).init
+         0     0%   100%     0.50MB  0.53%  runtime.bgscavenge

--- a/test/bench/pointer-static/description.md
+++ b/test/bench/pointer-static/description.md
@@ -1,9 +1,0 @@
-## Changes
-
-There are no major code changes. The main difference is that `getShard` now reads from a static value instead of a global variable.
-
-### Report
-
-Unexpectedly, disabling `procPin` has led to a significant performance degradation.
-
-Currently, **70% of the execution time** is consumed by atomic operations, compared to just **24% in the baseline**.


### PR DESCRIPTION
By optimizing getShard away, a lot of load was places on the atomic operations, which led to a 47x worse peformance result, exposing a very big bottleneck that proPin was taking care of, all changes will be descontinued.